### PR TITLE
Add spamFilter middleware to discourage abusive traffic

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,8 +76,11 @@ func main() {
 func spamFilter(next http.Handler) http.Handler {
 	isSpam := func(r *http.Request) bool {
 		switch {
-		// https://github.com/mccutchen/httpbingo.org/issues/1
 		case r.Method == http.MethodGet && r.URL.Path == "/stream-bytes/500000" && r.URL.Query().Get("nnn") != "":
+			// https://github.com/mccutchen/httpbingo.org/issues/1
+			return true
+		case r.Header.Get("User-Agent") == "Envoy/HC":
+			// https://github.com/mccutchen/httpbingo.org/issues/3
 			return true
 		default:
 			return false

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	var handler http.Handler
 	handler = h.Handler()
+	handler = spamFilter(handler)
 	handler = hlog.AccessHandler(requestLogger)(handler)
 	handler = hlog.NewHandler(logger)(handler)
 
@@ -67,6 +68,30 @@ func main() {
 	if err := listenAndServeGracefully(srv, maxDuration); err != nil {
 		logger.Fatal().Msgf("error starting server: %s", err)
 	}
+}
+
+// spamFilter is where we attempt to discourage abusive behavior. The actual
+// filtering is likely to evolve over time, based on observed behavior and
+// traffic patterns.
+func spamFilter(next http.Handler) http.Handler {
+	isSpam := func(r *http.Request) bool {
+		switch {
+		// https://github.com/mccutchen/httpbingo.org/issues/1
+		case r.Method == http.MethodGet && r.URL.Path == "/stream-bytes/500000" && r.URL.Query().Get("nnn") != "":
+			return true
+		default:
+			return false
+		}
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isSpam(r) {
+			time.Sleep(5 * time.Second)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func requestLogger(r *http.Request, status int, size int, duration time.Duration) {

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func spamFilter(next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isSpam(r) {
-			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			w.WriteHeader(http.StatusPaymentRequired)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/main.go
+++ b/main.go
@@ -86,7 +86,6 @@ func spamFilter(next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isSpam(r) {
-			time.Sleep(5 * time.Second)
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
This adds a mechanism to discourage abusive/unwanted traffic to the public https://httpbingo.org instance.  The first attempt here will sleep for 5 seconds before responding with a 500 Internal Server Error response, but we may need to change this strategy or adopt new strategies in the future.

Fixes #1.  See that issue for more context around the current traffic we want to discourage.